### PR TITLE
Fix An error occurred when I migrated...

### DIFF
--- a/lib/TableParser.pm
+++ b/lib/TableParser.pm
@@ -94,14 +94,16 @@ sub get_create_table {
    if ( my $e = $EVAL_ERROR ) {
       # Restore old SQL mode.
       PTDEBUG && _d($old_sql_mode);
-      $dbh->do($old_sql_mode);
+      eval { $dbh->do($old_sql_mode); };
+      PTDEBUG && $EVAL_ERROR && _d($EVAL_ERROR);
 
       die $e;
    }
 
    # Restore old SQL mode.
    PTDEBUG && _d($old_sql_mode);
-   $dbh->do($old_sql_mode);
+   eval { $dbh->do($old_sql_mode); };
+   PTDEBUG && $EVAL_ERROR && _d($EVAL_ERROR);
 
    # SHOW CREATE TABLE has at least 2 columns like:
    # mysql> show create table city\G


### PR DESCRIPTION
HI, i am back
An error occurred when I migrated data from MySQL to OceanBase:【 DBD::mysql::db do failed: You have an error in your SQL syntax; check the manual that corresponds to your OceanBase version for the right syntax to use near ':= @OLD_SQL_MODE, @@SQL_QUOTE_SHOW_CREATE := @OLD_QUOTE /' at line 1 [for Statement "/!40101 SET @@SQL_MODE := @OLD_SQL_MODE, @@SQL_QUOTE_SHOW_CREATE := @OLD_QUOTE */"] at /usr/bin/pt-archiver line 1932.】

I'm not a Perl programmer. But by reading the source code and making some changes, the migration was done successfully, so I submit this report


- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [x] util/update-modules has been ran
- [x] Not involved Documention updated
- [x] Not involved Test suite update
